### PR TITLE
Authentication Fix

### DIFF
--- a/lib/VarnishAdmin/VarnishAdminSocket.php
+++ b/lib/VarnishAdmin/VarnishAdminSocket.php
@@ -342,7 +342,8 @@ class VarnishAdminSocket implements VarnishAdmin
      */
     public function setSecret($secret)
     {
-        $this->secret = $secret;
+        // Secret requires a new line at the end, so if its not there, lets add it.
+        $this->secret = (strpos($secret, self::NEW_LINE) === (strlen($secret) - 1)) ? $secret : $secret.self::NEW_LINE;
     }
 
     /**

--- a/tests/VarnishAdminSocketTest.php
+++ b/tests/VarnishAdminSocketTest.php
@@ -158,7 +158,7 @@ class VarnishAdminSocketTest extends PHPUnit_Framework_TestCase
     public function testSetSecret()
     {
         $this->admin->setSecret('secret');
-        $this->assertEquals('secret', $this->admin->secret);
+        $this->assertEquals("secret\n", $this->admin->secret);
     }
 
     public function testStop()


### PR DESCRIPTION
Varnish secret needs to have an appended newline for authentication to function.  Tested in Varnish 4.1.9